### PR TITLE
Set challenge parameter on UnauthorizedHttpException

### DIFF
--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -110,7 +110,7 @@ class Auth
         $exception = array_shift($exceptionStack);
 
         if ($exception === null) {
-            $exception = new UnauthorizedHttpException(null, 'Failed to authenticate because of bad credentials or an invalid authorization header.');
+            $exception = new UnauthorizedHttpException('dingo', 'Failed to authenticate because of bad credentials or an invalid authorization header.');
         }
 
         throw $exception;


### PR DESCRIPTION
the first parameter of Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException can not be null in Symfony 4.